### PR TITLE
Fix borgbackup-job -h, --envfile re-introduced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Changed syntax: `--envfile <filename>` is now a required parameter
 ## [3.0.1]
 ### Changed
 - Suggestion for how to name passphrase files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Changed syntax: `--envfile <filename>` is now a required parameter
+- Command syntax: `--envfile <filename>` is now a required parameter
+
 ## [3.0.1]
 ### Changed
 - Suggestion for how to name passphrase files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Command syntax: `--envfile <filename>` is now a required parameter
 
+### Fixed
+- Naming convention of generated config files by setup.sh is now: <reponame>_<repolocation>
+
 ## [3.0.1]
 ### Changed
 - Suggestion for how to name passphrase files

--- a/borgbackup-job
+++ b/borgbackup-job
@@ -1,34 +1,34 @@
 #!/bin/bash
 
 PS4='+(${LINENO}) ' # add linenumbers to the trace when run with 'bash -x'
-short_usage="Usage: $NAME envfile [OPTION]... [PATHS_TO_BACKUP]"
 NAME=$(basename "$0")
+short_usage="Usage: $NAME -e filename [OPTIONS...] [PATHS_TO_BACKUP]"
 show_help()  {
   cat <<EOM  | sed -e's/^  //'   # left justify help
   ${short_usage}
   Create backup with Borg
 
-  envfile           Settings file for the backup to run
+  -e|--envfile filename   Settings file for the backup to run
 
   Options:
-    --help          Shows this help section
-    --exclude       Path to exclude from backup, can be stated multiple times
-                    This option is passed directly to borg,
-                    see "borg help patterns" for more info
-    --dry-run       Test run, without actually taking a backup.
+    --help                Shows this help section
+    --exclude             Path to exclude from backup, can be stated multiple times
+                          This option is passed directly to borg,
+                          see "borg help patterns" for more info
+    --dry-run             Test run, without actually taking a backup.
 
-  PATHS_TO_BACKUP   Files to backup. If given, this will override the files to backup
-                    specified in the settings file.
+  PATHS_TO_BACKUP         Files to backup. If given, this will override the files to backup
+                          specified in the settings file.
 
   Examples:
     # With required arguments
-    $NAME ~/.borgbackup/backup_host.env
+    $NAME --envfile ~/.borgbackup/backup_host.env
 
     # Override paths in envfile
-    $NAME ~/.borgbackup/backup_host.env /home/arthur/guide /home/arthur/memories-from-earth
+    $NAME -e ~/.borgbackup/backup_host.env /home/arthur/guide /home/arthur/memories-from-earth
 
     # Override exclude in envfile
-    $NAME ~/.borgbackup/backup_host.env /home/arthur/guide --exclude '*.secret' --exclude '*/guide/drafts'
+    $NAME -e ~/.borgbackup/backup_host.env /home/arthur/guide --exclude '*.secret' --exclude '*/guide/drafts'
 EOM
 }
 
@@ -52,7 +52,7 @@ abort() {
   # exits with exit code 2 and message on stderr, without timestamp
   # for user messages on commandline, i.e. at startup failure, where timestamp is ugly
   if [[ -n $1 ]]; then
-    printf "%s\n" "$*" >&2
+    echo -e "$*" >&2
   fi
   exit 2
 }
@@ -79,15 +79,7 @@ source_conf_file() {
 }
 
 init() {
-  if [[ $# -eq 0 ]]; then  # No parameters?
-    abort "$(show_help)"
-  fi
-
-  envfile="$1"
-  [[ -r ${envfile} ]] || abort "envfile needed\n$short_usage"
-  shift
-
-  options=$(getopt --name "$NAME" --longoptions "help,dry-run,exclude:" -- "" "$@")
+  options=$(getopt --name "$NAME" --longoptions "help,dry-run,exclude:,envfile:" -- "e:" "$@")
   # shellcheck disable=SC2181
   if [[ $? -ne 0 ]]; then # Problem with getting options?
     abort "$(show_help)"
@@ -101,25 +93,33 @@ init() {
   dry_run=false
   while true; do
     case $1 in
-      '--exclude')
+      --envfile|-e)
+        [[ ${2:0:1} != '-' ]] || abort "$1 requires a filename argument"
+        envfile="$2"
+        shift 2
+        ;;
+      --exclude)
         [[ ${2:0:1} != '-' ]] || abort "$1 requires an argument"
         excludes_on_cmdline+=("$2")
         shift 2
         ;;
-      '--dry-run')
+      --dry-run)
         dry_run=true
         shift
         ;;
-      '--help')
+      --help)
         show_help
         die 0
         ;;
-      '--') # Separator between optional and positional parameters
+      --) # Separator between optional and positional parameters
         shift
         break
         ;;
     esac
   done
+
+  [[ -z ${envfile} ]] && abort "--envfile (or -e) needed (try \"$NAME --help\")\n$short_usage"
+  [[ -r ${envfile} ]] || abort "envfile \"$envfile\" is not readable\n$short_usage"
 
   paths_on_cmdline=("$@")
   set --

--- a/borgbackup-job
+++ b/borgbackup-job
@@ -38,7 +38,7 @@ DEFAULT_CONFDIR="${HOME}/.borgbackup"
 info() {
   # print timestamped info on stderr
   if [[ -n $1 ]]; then
-    printf "\n%(%F_%T)T %s\n" -1 "$*" >&2
+    printf "%(%F_%T)T %s\n" -1 "$*" >&2
   fi
 }
 die() {
@@ -90,7 +90,7 @@ init() {
   unset options
 
   excludes_on_cmdline=()
-  dry_run=false
+  unset dry_run
   while true; do
     case $1 in
       --envfile|-e)
@@ -104,7 +104,7 @@ init() {
         shift 2
         ;;
       --dry-run)
-        dry_run=true
+        dry_run="true"
         shift
         ;;
       --help)
@@ -148,36 +148,35 @@ init() {
   fi
 }
 
+run_hooks() {
+  hooks=("$@")
+  for hook in "${hooks[@]}"; do
+    if [[ $(type -t $hook) == 'function' ]]; then
+      if [[ $dry_run ]]; then
+        info "Would run $hook hook"
+      else
+        info "Running $hook hook"
+        $hook
+      fi
+    fi
+  done
+}
+
 ## main
 init "$@"
 
-info "$NAME starting"
-trap 'info "$NAME ending"' EXIT
+info "$NAME starting ${dry_run:+"dry-run"}"
 
-if [[ $(type -t post_backup) == 'function' ]]; then
-  # use trap: in case 'borg create' fails we still want to restore system to production mode
-  trap 'info "Running post-backup hook" ; post_backup ; info "$NAME ending"' EXIT
+# use trap: in case 'borg create' fails we still want to restore system to production mode
+trap 'run_hooks post_backup ; info "$NAME ending"' EXIT
+
+run_hooks pre_backup
+
+if [[ $dry_run ]]; then
+  borg() {
+    info "Would run borg $*"
+  }
 fi
-
-if [[ $(type -t pre_backup) == 'function' ]]; then
-  info "Running pre-backup hook"
-  pre_backup
-fi
-
-if $dry_run; then
-  echo "Dry run"
-  echo "Exclude parameters: $EXCL"
-
-  dry_run_paths=()
-  for path in "${PATHS_TO_BACKUP[@]}"; do
-    dry_run_paths+=("$path")
-  done
-  echo "Paths to backup: ${dry_run_paths[*]}"
-
-  exit
-fi
-
-info "Starting borg backup"
 
 # shellcheck disable=SC2086
 borg create \

--- a/borgbackup-job
+++ b/borgbackup-job
@@ -43,7 +43,7 @@ info() {
 }
 die() {
   # exit with indicated exit code and
-  exitcode=$1
+  local exitcode=$1
   shift
   info "$*"
   exit "$exitcode"
@@ -59,7 +59,7 @@ abort() {
 warning_or_error() {
   # borg exit code = 1 is warning, others are error.
   # This translates the code to text used in message to user
-  code=$1
+  local code=$1
   ret="warning"
   [[ $code -gt 1 ]] && ret="error"
   echo $ret
@@ -67,7 +67,7 @@ warning_or_error() {
 trap 'die 2 "Backup interrupted"' INT TERM
 
 source_conf_file() {
-  unqualified_name="$1"
+  local unqualified_name="$1" filename
   if [[ -n $unqualified_name ]]; then
     filename="$unqualified_name"
     if [[ ${filename:0:1} != '/' ]]; then
@@ -79,6 +79,7 @@ source_conf_file() {
 }
 
 init() {
+  local options
   options=$(getopt --name "$NAME" --longoptions "help,dry-run,exclude:,envfile:" -- "e:" "$@")
   # shellcheck disable=SC2181
   if [[ $? -ne 0 ]]; then # Problem with getting options?
@@ -89,7 +90,7 @@ init() {
   eval set -- "$options"
   unset options
 
-  excludes_on_cmdline=()
+  local -a excludes_on_cmdline
   unset dry_run
   while true; do
     case $1 in
@@ -121,7 +122,7 @@ init() {
   [[ -z ${envfile} ]] && abort "--envfile (or -e) needed (try \"$NAME --help\")\n$short_usage"
   [[ -r ${envfile} ]] || abort "envfile \"$envfile\" is not readable\n$short_usage"
 
-  paths_on_cmdline=("$@")
+  local -a paths_on_cmdline=("$@")
   set --
 
   source_conf_file "$envfile"
@@ -149,9 +150,9 @@ init() {
 }
 
 run_hooks() {
-  hooks=("$@")
-  for hook in "${hooks[@]}"; do
-    if [[ $(type -t $hook) == 'function' ]]; then
+  local hooks_to_run=("$@")
+  for hook in "${hooks_to_run[@]}"; do
+    if [[ $(type -t "$hook") == 'function' ]]; then
       if [[ $dry_run ]]; then
         info "Would run $hook hook"
       else

--- a/borgbackup-job
+++ b/borgbackup-job
@@ -86,7 +86,7 @@ init() {
     abort "$(show_help)"
   fi
 
-  # Sets double dashes, which marks end of optional parameters
+  # Sets double dashes, which marks end of getopt parameters
   eval set -- "$options"
   unset options
 

--- a/borgbackup-job
+++ b/borgbackup-job
@@ -111,7 +111,7 @@ init() {
         show_help
         die 0
         ;;
-      --) # Separator between optional and positional parameters
+      --) # end of getopt parsed parameters
         shift
         break
         ;;

--- a/setup.sh
+++ b/setup.sh
@@ -170,7 +170,7 @@ EOF
   borg init --encryption=repokey-blake2 --verbose
 
   if read_Y_or_N "Should the passphrase be stored in a file in ${CONFDIR}? [y/n] "; then
-    passphrase_file="$(dirname $job_name_envfile)/.$(basename ${job_name_envfile%.env}).passphrase"
+    passphrase_file=$(dirname "$job_name_envfile")/.$(basename "$job_name_envfile" .env).passphrase
     echo "Creating $passphrase_file"
     umask_old=$(umask -p)
     umask 0377

--- a/setup.sh
+++ b/setup.sh
@@ -127,7 +127,7 @@ setup_job()  {
   done
 
   read -e -p 'Name of the backup job to create: ' job_name
-  job_name_envfile="${CONFDIR}/${repobase_file%.repobase}_${job_name}.env"
+  job_name_envfile="${CONFDIR}/${job_name}_${repobase_file%.repobase}.env"
   if [[ -f $job_name_envfile ]]; then
     echo "File $job_name_envfile already exists. Please remove it manually and try again!"
     sleep 2 # give user chance to realize there was a problem
@@ -170,7 +170,7 @@ EOF
   borg init --encryption=repokey-blake2 --verbose
 
   if read_Y_or_N "Should the passphrase be stored in a file in ${CONFDIR}? [y/n] "; then
-    passphrase_file=${CONFDIR}/.${repobase_file%.repobase}_${job_name}.passphrase
+    passphrase_file="$(dirname $job_name_envfile)/.$(basename ${job_name_envfile%.env}).passphrase"
     echo "Creating $passphrase_file"
     umask_old=$(umask -p)
     umask 0377


### PR DESCRIPTION
envfile is (re-)introduced as required parameter to distinguish
from the (optional) paths-to-backup parameter(s), and to abort
with help text if no envfile is given.

Fixes #9