### PR TITLE
Don't fail if --envfile contains path

### DIFF
--- a/borgbackup-job
+++ b/borgbackup-job
@@ -171,9 +171,10 @@ add_timestamp() {
 }
 
 setup_logging() {
-  local logdir logname
+  local logdir logname envfile_nopath
   logdir=${LOGDIR:-"/var/log/borgbackup"}
-  logname=${envfile%%.env}."$(date +%d)".log
+  envfile_nopath=$(basename $envfile)
+  logname=${envfile_nopath%%.env}."$(date +%d)".log
   declare -g logfile="$logdir/$logname"
 
   mkdir -p "$logdir" || die 1 "unable to create logdir=$logdir" # don't accidentally delete files in next lines

--- a/borgbackup-job
+++ b/borgbackup-job
@@ -173,7 +173,7 @@ add_timestamp() {
 setup_logging() {
   local logdir logname envfile_nopath
   logdir=${LOGDIR:-"/var/log/borgbackup"}
-  envfile_nopath=$(basename $envfile)
+  envfile_nopath=$(basename "$envfile")
   logname=${envfile_nopath%%.env}."$(date +%d)".log
   declare -g logfile="$logdir/$logname"
 


### PR DESCRIPTION
If --envfile was given with path borgbackup-job failed in setup_logging,
with error:
touch: cannot touch '/var/log/borgbackup//root/.borgbackup/[project-name].30.log': No such file or directory
unable to create file /var/log/borgbackup//root/.borgbackup/[project-name].30.log

Now we remove the path from the envfile value before constructing
the logfile name.

Fixes #18