### PR TITLE
Retry at failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Retry backup if failed. New parameters in .env file: MAX_RETRY_COUNT and RETRY_DELAY_HOURS
+- Locking to prevent parallel running of same backup
 
 ## [4.1.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Retry backup if failed. New parameters in .env file: MAX_RETRY_COUNT and RETRY_DELAY_HOURS
 
 ## [4.1.1]
 ### Fixed

--- a/borgbackup-job
+++ b/borgbackup-job
@@ -33,6 +33,8 @@ EOM
 }
 
 DEFAULT_CONFDIR="${HOME}/.borgbackup"
+MAX_RETRY_COUNT=10
+RETRY_DELAY_HOURS=2
 
 # Some helpers and error handling
 info() {
@@ -81,7 +83,8 @@ source_conf_file() {
 
 init() {
   local options
-  options=$(getopt --name "$NAME" --longoptions "help,dry-run,exclude:,envfile:" -- "e:" "$@")
+  declare -g orig_options="$*"
+  options=$(getopt --name "$NAME" --longoptions "help,dry-run,exclude:,envfile:,_rerun:" -- "e:" "$@")
   # shellcheck disable=SC2181
   if [[ $? -ne 0 ]]; then # Problem with getting options?
     die 2 "$(show_help)"
@@ -108,6 +111,11 @@ init() {
       --dry-run)
         dry_run="true"
         shift
+        ;;
+      --_rerun)
+        [[ ${2:0:1} != '-' ]] || die 2 "$1 requires an argument"
+        rerun_counter="$2"
+        shift 2
         ;;
       --help)
         show_help
@@ -243,7 +251,7 @@ healthcheck_report() {
 ## main
 init "$@"
 setup_logging
-start_message="$NAME starting ${dry_run:+"dry-run"}"
+start_message="$NAME starting${dry_run:+" dry-run"}${rerun_counter:+" (rerun $rerun_counter)"}"
 info "$start_message"
 
 
@@ -274,7 +282,17 @@ borg create \
 
 borg_result=$?
 if (( borg_result > 0 ));then
-  info "borg create ended with $(warning_or_error $borg_result) ($borg_result). Not pruning repository"
+  (( rerun_counter = rerun_counter + 1 ))
+  if (( rerun_counter <= MAX_RETRY_COUNT ));then
+    info "borg create ended with $(warning_or_error $borg_result) ($borg_result). Scheduling rerun in $RETRY_DELAY_HOURS hours"
+    rerun_options="$(sed -Ee 's/--_rerun ..?//' <<< $orig_options) --_rerun $rerun_counter"
+    echo "$0 $rerun_options" | at "now + $RETRY_DELAY_HOURS hours"
+  else
+    if  (( rerun_counter != 1 ));then
+      rerun_msg=" Max retry attempts ($MAX_RETRY_COUNT) have failed. Not retrying."
+    fi
+    info "borg create ended with $(warning_or_error $borg_result) ($borg_result).$rerun_msg Not pruning repository"
+  fi
 else
   info "\nPruning repository:"
   borg prune \

--- a/borgbackup-job
+++ b/borgbackup-job
@@ -169,6 +169,16 @@ init() {
   fi
 }
 
+take_lock_or_die() {
+  lockfile="$(expand_filename_to_source "$envfile")"
+  exec {lockfd}<"$lockfile"
+  if flock --exclusive --nonblock $lockfd; then
+    :
+  else
+    die 1 "Backup already running. Exiting"
+  fi
+}
+
 add_timestamp() {
   # adds timestamp to each line. To be called from a subprocess, since it never returns
   IFS=  # preserve leading/trailing whitespace in read
@@ -250,6 +260,7 @@ healthcheck_report() {
 
 ## main
 init "$@"
+take_lock_or_die
 setup_logging
 start_message="$NAME starting${dry_run:+" dry-run"}${rerun_counter:+" (rerun $rerun_counter)"}"
 info "$start_message"
@@ -285,7 +296,7 @@ if (( borg_result > 0 ));then
   (( rerun_counter = rerun_counter + 1 ))
   if (( rerun_counter <= MAX_RETRY_COUNT ));then
     info "borg create ended with $(warning_or_error $borg_result) ($borg_result). Scheduling rerun in $RETRY_DELAY_HOURS hours"
-    rerun_options="$(sed -Ee 's/--_rerun ..?//' <<< $orig_options) --_rerun $rerun_counter"
+    rerun_options="$(sed -Ee 's/--_rerun ..?//' <<< "$orig_options") --_rerun $rerun_counter"
     echo "$0 $rerun_options" | at "now + $RETRY_DELAY_HOURS hours"
   else
     if  (( rerun_counter != 1 ));then

--- a/job.template.env
+++ b/job.template.env
@@ -28,3 +28,7 @@ HOOKS=job.template.hooks
 # integration with https://healthchecks.io
 #HEALTHCHECKS_PINGKEY=
 #HEALTHCHECKS_SLUG=
+
+# Parameters for retry at backup failure, with default values.  MAX_RETRY_COUNT=0 disables.
+#MAX_RETRY_COUNT=10
+#RETRY_DELAY_HOURS=2


### PR DESCRIPTION
Add retry at failure and locking to prevent problem if parallel backups happens.
Borg has its' own locking of repos, so clobbering the actual data cannot happen, but 
the locking is to protect the pre- and post- script side effects. 
The lock is on the envfile, so if different envfiles exists for same pre-/post-scripts problems are not avoided.
This could be fixed by introducing a LOCKFILE in the envfile and lock against that instead, but I'm not sure
the need exists. 