### PR TITLE
Add start time to the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Retry backup if failed. New parameters in .env file: MAX_RETRY_COUNT and RETRY_DELAY_HOURS
 - Locking to prevent parallel running of same backup
+- Add start time to the log of borg_server_side_checks
 
 ## [4.1.1]
 ### Fixed

--- a/borg_serverside_checks
+++ b/borg_serverside_checks
@@ -357,6 +357,8 @@ main() {
   init "$@"
   local ret # function return variable
 
+  register_result "$(date "+%F %T")" "$NAME starting at"
+
   setup_logging "${conf[logdir]}"
 
   healthcheck_report start


### PR DESCRIPTION
In case the checks did not run, the status on healthchecks.io
is red (due to missed schedule), but last log showed success
since the old one succeeded.

Add timestamp to the log to make this clear.